### PR TITLE
Make extension compatible with TYPO3 v8

### DIFF
--- a/Classes/Hooks/ContentPostProcessorHook.php
+++ b/Classes/Hooks/ContentPostProcessorHook.php
@@ -119,11 +119,12 @@ class ContentPostProcessorHook {
   protected function getConfiguration(array $rawConfiguration) {
 
     $configuration = isset($rawConfiguration['cors.']) ? $rawConfiguration['cors.'] : [];
+    $typo3SevenOrNewer = version_compare(TYPO3_version, '7.0', '>=');
 
     foreach ($configuration as $option => $value) {
 
       // Perform stdWrap processing on all options
-      if (version_compare(TYPO3_version, '7.0', '>=')) {
+      if ($typo3SevenOrNewer) {
         $endsWith = StringUtility::endsWith($option, '.');
       } else {
         $endsWith = StringUtility::isLastPartOfString($option, '.');

--- a/Classes/Hooks/ContentPostProcessorHook.php
+++ b/Classes/Hooks/ContentPostProcessorHook.php
@@ -123,7 +123,12 @@ class ContentPostProcessorHook {
     foreach ($configuration as $option => $value) {
 
       // Perform stdWrap processing on all options
-      if (StringUtility::isLastPartOfString($option, '.') && isset($value['stdWrap.'])) {
+      if (version_compare(TYPO3_version, '7.0', '>=')) {
+        $endsWith = StringUtility::endsWith($option, '.');
+      } else {
+        $endsWith = StringUtility::isLastPartOfString($option, '.');
+      }
+      if ($endsWith && isset($value['stdWrap.'])) {
 
         unset($configuration[$option]);
         $option = substr($option, 0, -1);

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -11,7 +11,7 @@ $EM_CONF[$_EXTKEY] = [
   'version' => '2.0.3',
   'constraints' => [
     'depends' => [
-      'typo3' => '6.2.0-7.6.99',
+      'typo3' => '6.2.0-8.99.99',
     ],
     'conflicts' => [
     ],


### PR DESCRIPTION
StringUtility::isLastPartOfString() is deprecated in TYPO3 7 and removed in TYPO3 8:

[https://docs.typo3.org/typo3cms/extensions/core/8-dev/singlehtml/Index.html#breaking-72431-remove-deprecated-code-from-lowlevel-and-utility-functions](url)