### PR TITLE
[BUGFIX] Don't require typo3/cms package

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,9 @@ jobs:
   include:
     - php: 5.6
       env: TYPO3_VERSION=^7.6
+      script:
+        - composer lint:php
+        - composer test
     - php: 7.0
       env: TYPO3_VERSION=^7.6
     - php: 7.1
@@ -26,14 +29,12 @@ jobs:
       env: TYPO3_VERSION=^8.7
 
     - &lint
-      php: 5.6
+      php: 7.0
       env: PHP lint
       install:
         - composer install
       script:
         - composer lint:php
-    - <<: *lint
-      php: 7.0
     - <<: *lint
       php: 7.1
 

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,8 @@
   "type": "typo3-cms-extension",
   "require": {
     "php": "^5.6 || ^7.0",
-    "typo3/cms": "^6.2 || ^7.6 || ^8.7"
+    "typo3/cms-core": "^6.2 || ^7.6 || ^8.7",
+    "typo3/cms-frontend": "^6.2 || ^7.6 || ^8.7"
   },
   "require-dev": {
     "jakub-onderka/php-console-highlighter": "^0.3.2",


### PR DESCRIPTION
We must not require the whole typo3/cms package for production
since this basically prevents installation of selected TYPO3 packages.