### PR TITLE
If origin-Header not contains port (e.g. default port), request is always a cross domain request.

### DIFF
--- a/Classes/AccessControl/Request.php
+++ b/Classes/AccessControl/Request.php
@@ -130,7 +130,7 @@ class Request {
 
       $this->isCrossOrigin = $this->origin->getScheme() != $this->destination->getScheme() ||
         $this->origin->getHostname() != $this->destination->getHostname() ||
-        $this->origin->getPort() != $this->destination->getPort();
+        $this->origin->getNormalizedPort() !== $this->destination->getNormalizedPort();
 
       $this->hasCredentials = isset($environment['HTTP_COOKIE']) ||
         isset($environment['HTTP_AUTHORIZATION']) ||

--- a/Classes/Http/Uri.php
+++ b/Classes/Http/Uri.php
@@ -63,10 +63,35 @@ class Uri {
   protected $port;
 
   /**
-   * @return integer
+   * @return integer|null
    */
   public function getPort() {
     return $this->port;
+  }
+
+  /**
+   * The normalized port, 443 for HTTPS and 80 for HTTP unless explicitly set
+   *
+   * @return integer|null
+   */
+  public function getNormalizedPort() {
+    $normalizedPort = $this->getPort();
+
+    if (empty($normalizedPort)) {
+
+      switch ($this->getScheme()) {
+
+        case 'https':
+          $normalizedPort = 443;
+          break;
+
+        case 'http':
+          $normalizedPort = 80;
+          break;
+      }
+    }
+
+    return $normalizedPort;
   }
 
   /**

--- a/Tests/Unit/AccessControl/RequestTest.php
+++ b/Tests/Unit/AccessControl/RequestTest.php
@@ -107,6 +107,23 @@ class RequestTest extends UnitTestCase {
         ],
         TRUE,
       ],
+      'Implicit origin port' => [
+        [
+          'HTTP_ORIGIN' => 'https://example.org',
+          'HTTP_HOST' => 'example.org',
+          'HTTPS' => 'on',
+          'SERVER_PORT' => 443,
+        ],
+        FALSE,
+      ],
+      'Implicit destination port' => [
+        [
+          'HTTP_ORIGIN' => 'https://example.org:443',
+          'HTTP_HOST' => 'example.org',
+          'HTTPS' => 'on',
+        ],
+        FALSE,
+      ],
     ];
   }
 

--- a/Tests/Unit/Http/UriTest.php
+++ b/Tests/Unit/Http/UriTest.php
@@ -74,6 +74,52 @@ class UriTest extends UnitTestCase {
 
   /**
    * @test
+   * @dataProvider environmentsWithoutPort
+   *
+   * @param array $environment
+   * @param int $expectedPort
+   */
+  public function returnsNormalizedPort(array $environment, $expectedPort) {
+
+    $uri = Uri::fromEnvironment($environment);
+
+    $this->assertEquals($expectedPort, $uri->getNormalizedPort());
+  }
+
+  /**
+   * @return array
+   */
+  public function environmentsWithoutPort() {
+
+    return [
+      'HTTPS' => [
+        [
+          'HTTP_HOST' => 'example.org',
+          'HTTPS' => 'on',
+          'REQUEST_URI' => '/',
+        ],
+        443,
+      ],
+      'HTTP' => [
+        [
+          'HTTP_HOST' => 'example.org',
+          'REQUEST_URI' => '/',
+        ],
+        80,
+      ],
+      'HTTP with custom port' => [
+        [
+          'HTTP_HOST' => 'example.org',
+          'SERVER_PORT' => 8080,
+          'REQUEST_URI' => '/',
+        ],
+        8080,
+      ],
+    ];
+  }
+
+  /**
+   * @test
    * @expectedException InvalidArgumentException
    * @expectedExceptionCode 1446565362
    */


### PR DESCRIPTION
Currently Origin-Header with `http://example.com` is resolved to `getPort() = null`. 
`Uri::fromEnvironment` set the Port from $_SERVER, which should always defined, so the check, `origin->getPort() != destination->getPort()`  (in Request-Constructor) is always true.

This Pull-Request set the default Port (80 or 443), if port is not given in `HTTP_ORIGIN`