### PR TITLE
[BUGFIX] Check also HTTP_X_FORWARDED_PORT for cross origin check

### DIFF
--- a/Classes/Http/Uri.php
+++ b/Classes/Http/Uri.php
@@ -253,7 +253,13 @@ class Uri
             : 'http'
         );
         $uri->setHostname($environment['HTTP_HOST']);
-        $uri->setPort(isset($environment['SERVER_PORT']) ? (int) $environment['SERVER_PORT'] : null);
+        $uri->setPort(
+            isset($environment['HTTP_X_FORWARDED_PORT'])
+            ? (int) $environment['HTTP_X_FORWARDED_PORT']
+            : (
+                isset($environment['SERVER_PORT']) ? (int) $environment['SERVER_PORT'] : null
+            )
+        );
         $uri->setUsername(isset($environment['PHP_AUTH_USER']) ? $environment['PHP_AUTH_USER'] : null);
         $uri->setPassword(isset($environment['PHP_AUTH_PW']) ? $environment['PHP_AUTH_PW'] : null);
 

--- a/Tests/Unit/Http/UriTest.php
+++ b/Tests/Unit/Http/UriTest.php
@@ -226,12 +226,12 @@ class UriTest extends UnitTestCase
                     'fragment' => null,
                 ],
             ],
-            'HTTPS through proxy with forwarded proto' => [
+            'HTTPS through proxy with forwarded port' => [
                 [
                     'HTTP_HOST' => 'example.org',
                     'HTTP_X_FORWARDED_PROTO' => 'https',
                     'HTTP_X_FORWARDED_PORT' => 443,
-                    'SERVER_PORT' => 81,
+                    'SERVER_PORT' => 80,
                     'REQUEST_URI' => '/',
                 ],
                 [

--- a/Tests/Unit/Http/UriTest.php
+++ b/Tests/Unit/Http/UriTest.php
@@ -226,6 +226,25 @@ class UriTest extends UnitTestCase
                     'fragment' => null,
                 ],
             ],
+            'HTTPS through proxy with forwarded proto' => [
+                [
+                    'HTTP_HOST' => 'example.org',
+                    'HTTP_X_FORWARDED_PROTO' => 'https',
+                    'HTTP_X_FORWARDED_PORT' => 443,
+                    'SERVER_PORT' => 81,
+                    'REQUEST_URI' => '/',
+                ],
+                [
+                    'scheme' => 'https',
+                    'hostname' => 'example.org',
+                    'port' => 443,
+                    'username' => null,
+                    'password' => null,
+                    'path' => '/',
+                    'query' => null,
+                    'fragment' => null,
+                ],
+            ],
         ];
     }
 


### PR DESCRIPTION
In addition to #22  , which is works on the most enviroments for us, we have now the problem, that the `$_SERVER['PORT']` could be different to the scheme.

An example setup:
LoadBalancer :443 -> Nginx :80 -> PHP
Nginx sets `HTTP_X_FORWARDED_PROTO` to "https" and `HTTPS` to "on". 

Currently cors check fails, because Port 443  is used for check:

```
curl -s --head -X POST -H "Origin: https://typo3.example.com" "https://typo3.example.com/ajax"
# returns **204 "No Content" => No OK**

curl -s --head -X POST -H "Origin: https://typo3.example.com:80" "https://typo3.example.com/ajax"
# returns **200 => OK**
```

We also set the [`HTTP_X_FORWARDED_PORT`](https://docs.aws.amazon.com/elasticloadbalancing/latest/classic/x-forwarded-headers.html#x-forwarded-port)-Header which is set to 443, but is not checked by cores.